### PR TITLE
Update for draft11 protocol implementation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Version history
 ===============
 
+### 2.4.0 (2014-04-16) ###
+
+* Upgrade to the latest draft: [draft-ietf-httpbis-http2-11]
+
+[draft-ietf-httpbis-http2-11]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-11
+
 ### 2.3.0 (2014-03-12) ###
 
 * Upgrade to the latest draft: [draft-ietf-httpbis-http2-10]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-http2
 ==========
 
-An HTTP/2 ([draft-ietf-httpbis-http2-10](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10))
+An HTTP/2 ([draft-ietf-httpbis-http2-11](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11))
 client and server implementation for node.js.
 
 Installation

--- a/lib/http.js
+++ b/lib/http.js
@@ -121,7 +121,7 @@
 //
 // [1]: http://nodejs.org/api/https.html
 // [2]: http://nodejs.org/api/http.html
-// [3]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-8.1.3.2
+// [3]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-8.1.3.2
 // [expect-continue]: https://github.com/http2/http2-spec/issues/18
 // [connect]: https://github.com/http2/http2-spec/issues/230
 
@@ -204,7 +204,7 @@ function IncomingMessage(stream) {
 }
 IncomingMessage.prototype = Object.create(PassThrough.prototype, { constructor: { value: IncomingMessage } });
 
-// [Request Header Fields](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-8.1.3.1)
+// [Request Header Fields](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-8.1.3.1)
 // * `headers` argument: HTTP/2.0 request and response header fields carry information as a series
 //   of key-value pairs. This includes the target URI for the request, the status code for the
 //   response, as well as HTTP header fields.
@@ -516,7 +516,7 @@ function IncomingRequest(stream) {
 }
 IncomingRequest.prototype = Object.create(IncomingMessage.prototype, { constructor: { value: IncomingRequest } });
 
-// [Request Header Fields](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-8.1.3.1)
+// [Request Header Fields](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-8.1.3.1)
 // * `headers` argument: HTTP/2.0 request and response header fields carry information as a series
 //   of key-value pairs. This includes the target URI for the request, the status code for the
 //   response, as well as HTTP header fields.
@@ -947,7 +947,7 @@ function IncomingResponse(stream) {
 }
 IncomingResponse.prototype = Object.create(IncomingMessage.prototype, { constructor: { value: IncomingResponse } });
 
-// [Response Header Fields](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-8.1.3.2)
+// [Response Header Fields](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-8.1.3.2)
 // * `headers` argument: HTTP/2.0 request and response header fields carry information as a series
 //   of key-value pairs. This includes the target URI for the request, the status code for the
 //   response, as well as HTTP header fields.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-// [node-http2][homepage] is an [HTTP/2 (draft 10)][http2] implementation for [node.js][node].
+// [node-http2][homepage] is an [HTTP/2 (draft 11)][http2] implementation for [node.js][node].
 //
 // The core of the protocol is implemented by the [http2-protocol] module. This module provides
 // two important features on top of http2-protocol:
@@ -11,7 +11,7 @@
 //
 // [homepage]:            https://github.com/molnarg/node-http2
 // [http2-protocol]:      https://github.com/molnarg/node-http2-protocol
-// [http2]:               http://tools.ietf.org/html/draft-ietf-httpbis-http2-10
+// [http2]:               http://tools.ietf.org/html/draft-ietf-httpbis-http2-11
 // [node]:                http://nodejs.org/
 // [node-https]:          http://nodejs.org/api/https.html
 // [node-http]:           http://nodejs.org/api/http.html

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node" : ">=0.10.19"
   },
   "dependencies": {
-    "http2-protocol": "0.10.x"
+    "http2-protocol": "0.11.x"
   },
   "devDependencies": {
     "istanbul": "*",


### PR DESCRIPTION
Just a minor update to depend on the draft11 implementation in node-http2-protocol.
