### PR TITLE
Plumb in ALTSVC

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -677,6 +677,13 @@ OutgoingResponse.prototype.push = function push(options) {
   return new OutgoingResponse(pushStream);
 };
 
+OutgoingResponse.prototype.altsvc = function altsvc(host, port, protocolID, maxAge, origin) {
+    if (origin === undefined) {
+        origin = "";
+    }
+    this.stream.altsvc(host, port, protocolID, maxAge, origin);
+};
+
 // Overriding `EventEmitter`'s `on(event, listener)` method to forward certain subscriptions to
 // `request`. See `Server.prototype.on` for explanation.
 OutgoingResponse.prototype.on = function on(event, listener) {


### PR DESCRIPTION
This is the client library implementation to be able to send ALTSVC frames. I didn't force the NPN token to be the current version, because there may come a time when people actually want to send ALTSVC for a non-http/2 endpoint.
