### PR TITLE
Give the stream a reference to the connection

### DIFF
--- a/lib/protocol/connection.js
+++ b/lib/protocol/connection.js
@@ -157,7 +157,7 @@ Connection.prototype._changeStreamCount = function _changeStreamCount(change) {
 // Creating a new *inbound or outbound* stream with the given `id` (which is undefined in case of
 // an outbound stream) consists of three steps:
 //
-// 1. var stream = new Stream(this._log);
+// 1. var stream = new Stream(this._log, this);
 // 2. this._allocateId(stream, id);
 // 2. this._allocatePriority(stream);
 
@@ -230,7 +230,7 @@ Connection.prototype._reprioritize = function _reprioritize(stream, priority) {
 Connection.prototype._createIncomingStream = function _createIncomingStream(id) {
   this._log.debug({ stream_id: id }, 'New incoming stream.');
 
-  var stream = new Stream(this._log);
+  var stream = new Stream(this._log, this);
   this._allocateId(stream, id);
   this._allocatePriority(stream);
   this.emit('stream', stream, id);
@@ -243,7 +243,7 @@ Connection.prototype.createStream = function createStream() {
   this._log.trace('Creating new outbound stream.');
 
   // * Receiving is enabled immediately, and an ID gets assigned to the stream
-  var stream = new Stream(this._log);
+  var stream = new Stream(this._log, this);
   this._allocatePriority(stream);
 
   return stream;

--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -16,7 +16,7 @@ exports.Stream = Stream;
 // Public API
 // ----------
 
-// * **new Stream(log)**: create a new Stream
+// * **new Stream(log, connection)**: create a new Stream
 //
 // * **Event: 'headers' (headers)**: signals incoming headers
 //
@@ -46,7 +46,7 @@ exports.Stream = Stream;
 // -----------
 
 // The main aspects of managing the stream are:
-function Stream(log) {
+function Stream(log, connection) {
   Duplex.call(this);
 
   // * logging
@@ -60,6 +60,8 @@ function Stream(log) {
 
   // * maintaining the state of the stream (idle, open, closed, etc.) and error detection
   this._initializeState();
+
+  this.connection = connection;
 }
 
 Stream.prototype = Object.create(Duplex.prototype, { constructor: { value: Stream } });
@@ -79,7 +81,7 @@ Stream.prototype._initializeManagement = function _initializeManagement() {
 };
 
 Stream.prototype.promise = function promise(headers) {
-  var stream = new Stream(this._log);
+  var stream = new Stream(this._log, this.connection);
   stream._priority = Math.min(this._priority + 1, MAX_PRIORITY);
   this._pushUpstream({
     type: 'PUSH_PROMISE',

--- a/test/stream.js
+++ b/test/stream.js
@@ -5,7 +5,7 @@ var stream = require('../lib/protocol/stream');
 var Stream = stream.Stream;
 
 function createStream() {
-  var stream = new Stream(util.log);
+  var stream = new Stream(util.log, null);
   stream.upstream._window = Infinity;
   return stream;
 }
@@ -106,7 +106,7 @@ var example_frames = [
   { type: 'RST_STREAM', flags: {}, error: 'CANCEL' },
   { type: 'HEADERS', flags: {}, headers: {}, priority: undefined },
   { type: 'DATA', flags: {}, data: new Buffer(5) },
-  { type: 'PUSH_PROMISE', flags: {}, headers: {}, promised_stream: new Stream(util.log) }
+  { type: 'PUSH_PROMISE', flags: {}, headers: {}, promised_stream: new Stream(util.log, null) }
 ];
 
 var invalid_incoming_frames = {
@@ -173,7 +173,7 @@ var invalid_outgoing_frames = {
     { type: 'WINDOW_UPDATE', flags: {}, settings: {} },
     { type: 'HEADERS', flags: {}, headers: {}, priority: undefined },
     { type: 'DATA', flags: {}, data: new Buffer(5) },
-    { type: 'PUSH_PROMISE', flags: {}, headers: {}, promised_stream: new Stream(util.log) }
+    { type: 'PUSH_PROMISE', flags: {}, headers: {}, promised_stream: new Stream(util.log, null) }
   ]
 };
 


### PR DESCRIPTION
This is a non-protocol change that is required to support testing a bugfix in firefox. All it does is gives the stream a reference to the connection so that we can get to the connection from the request handling callback in our test server.
