### PR TITLE
allow receipt of PRIORITY in idle state

### DIFF
--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -443,6 +443,8 @@ Stream.prototype._transition = function transition(sending, frame) {
         this._initiated = sending;
       } else if (sending && RST_STREAM) {
         this._setState('CLOSED');
+      } else if (PRIORITY) {
+        /* No state change */
       } else {
         connectionError = 'PROTOCOL_ERROR';
       }


### PR DESCRIPTION
Spec 5.1 Stream States -> idle  "Receiving any frames other than
HEADERS, PUSH_PROMISE or PRIORITY on a stream in this state MUST
be treated as a connection error (Section 5.4.1) of type PROTOCOL_ERROR."

This is useful for creating dependency grouping nodes in the priority
dependency tree - the group nodes are streams that may never opened.

section 5.3.4 "Similarly, streams that are in the "idle" state can be assigned
priority or become a parent of other streams.  This allows for the
creation of a grouping node in the dependency tree, which enables
more flexible expressions of priority.  Idle streams that are made
a parent of another stream are assigned a default priority
(Section 5.3.5)."
