### PR TITLE
Properly support PRIORITY in all states

### DIFF
--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -464,7 +464,7 @@ Stream.prototype._transition = function transition(sending, frame) {
         this._setState('HALF_CLOSED_REMOTE');
       } else if (RST_STREAM) {
         this._setState('CLOSED');
-      } else if (receiving && PRIORITY) {
+      } else if (PRIORITY) {
         /* No state change */
       } else {
         connectionError = 'PROTOCOL_ERROR';
@@ -483,7 +483,7 @@ Stream.prototype._transition = function transition(sending, frame) {
         this._setState('CLOSED');
       } else if (receiving && HEADERS) {
         this._setState('HALF_CLOSED_LOCAL');
-      } else if (BLOCKED || (sending && PRIORITY)) {
+      } else if (BLOCKED || PRIORITY) {
         /* No state change */
       } else {
         connectionError = 'PROTOCOL_ERROR';
@@ -518,7 +518,7 @@ Stream.prototype._transition = function transition(sending, frame) {
     case 'HALF_CLOSED_LOCAL':
       if (RST_STREAM || (receiving && frame.flags.END_STREAM)) {
         this._setState('CLOSED');
-      } else if (BLOCKED || ALTSVC ||receiving || (sending && (PRIORITY || WINDOW_UPDATE))) {
+      } else if (BLOCKED || ALTSVC || receiving || PRIORITY || (sending && WINDOW_UPDATE)) {
         /* No state change */
       } else {
         connectionError = 'PROTOCOL_ERROR';
@@ -538,7 +538,7 @@ Stream.prototype._transition = function transition(sending, frame) {
     case 'HALF_CLOSED_REMOTE':
       if (RST_STREAM || (sending && frame.flags.END_STREAM)) {
         this._setState('CLOSED');
-      } else if (BLOCKED || ALTSVC ||sending || (receiving && (WINDOW_UPDATE || PRIORITY))) {
+      } else if (BLOCKED || ALTSVC || sending || PRIORITY || (receiving && WINDOW_UPDATE)) {
         /* No state change */
       } else {
         connectionError = 'PROTOCOL_ERROR';
@@ -566,9 +566,9 @@ Stream.prototype._transition = function transition(sending, frame) {
     //   causes a stream to become "reserved". If promised streams are not desired, a RST_STREAM
     //   can be used to close any of those streams.
     case 'CLOSED':
-      if ((sending && RST_STREAM) ||
+      if (PRIORITY || (sending && RST_STREAM) ||
           (receiving && this._closedByUs &&
-           (this._closedWithRst || WINDOW_UPDATE || PRIORITY || RST_STREAM || ALTSVC))) {
+           (this._closedWithRst || WINDOW_UPDATE || RST_STREAM || ALTSVC))) {
         /* No state change */
       } else {
         streamError = 'STREAM_CLOSED';

--- a/test/stream.js
+++ b/test/stream.js
@@ -112,7 +112,6 @@ var example_frames = [
 var invalid_incoming_frames = {
   IDLE: [
     { type: 'DATA', flags: {}, data: new Buffer(5) },
-    { type: 'PRIORITY', flags: {}, priority: 1 },
     { type: 'WINDOW_UPDATE', flags: {}, settings: {} },
     { type: 'PUSH_PROMISE', flags: {}, headers: {} },
     { type: 'RST_STREAM', flags: {}, error: 'CANCEL' }
@@ -125,7 +124,6 @@ var invalid_incoming_frames = {
   ],
   RESERVED_REMOTE: [
     { type: 'DATA', flags: {}, data: new Buffer(5) },
-    { type: 'PRIORITY', flags: {}, priority: 1 },
     { type: 'PUSH_PROMISE', flags: {}, headers: {} },
     { type: 'WINDOW_UPDATE', flags: {}, settings: {} }
   ],
@@ -143,13 +141,11 @@ var invalid_incoming_frames = {
 var invalid_outgoing_frames = {
   IDLE: [
     { type: 'DATA', flags: {}, data: new Buffer(5) },
-    { type: 'PRIORITY', flags: {}, priority: 1 },
     { type: 'WINDOW_UPDATE', flags: {}, settings: {} },
     { type: 'PUSH_PROMISE', flags: {}, headers: {} }
   ],
   RESERVED_LOCAL: [
     { type: 'DATA', flags: {}, data: new Buffer(5) },
-    { type: 'PRIORITY', flags: {}, priority: 1 },
     { type: 'PUSH_PROMISE', flags: {}, headers: {} },
     { type: 'WINDOW_UPDATE', flags: {}, settings: {} }
   ],
@@ -169,7 +165,6 @@ var invalid_outgoing_frames = {
   HALF_CLOSED_REMOTE: [
   ],
   CLOSED: [
-    { type: 'PRIORITY', flags: {}, priority: 1 },
     { type: 'WINDOW_UPDATE', flags: {}, settings: {} },
     { type: 'HEADERS', flags: {}, headers: {}, priority: undefined },
     { type: 'DATA', flags: {}, data: new Buffer(5) },
@@ -197,7 +192,7 @@ describe('stream.js', function() {
         stream.headers({});
         stream.end();
         stream.upstream.write({ type: 'HEADERS', headers:{}, flags: { END_STREAM: true }, count_change: util.noop });
-        example_frames.forEach(function(invalid_frame) {
+        example_frames.slice(1).forEach(function(invalid_frame) {
           invalid_frame.count_change = util.noop;
           expect(stream._transition.bind(stream, false, invalid_frame)).to.throw('Uncaught, unspecified "error" event.');
         });


### PR DESCRIPTION
Spec allows PRIORITY to be sent/received in absolutely any state now. This bundle's the changes from #90 in with a bunch of other changes to allow PRIORITY in any state, and fix the tests. After merging this, we should probably bump the advertised version to h2-16 before releasing version 3.0.2 (I'll prepare that patch, as well), since this is a change since drafts 14 and 15.

@mcmanus - mind giving this a quick once-over to see if I missed anything else obvious?
