### PR TITLE
Forward all `Agent` options to the underlying `https.Agent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,20 @@ require('http2').createServer(options, function(request, response) {
 ### Using as a client ###
 
 ```javascript
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
 require('http2').get('https://localhost:8080/', function(response) {
+  response.pipe(process.stdout);
+});
+```
+
+Self-signed certificates must be specified for each request to avoid
+verification errors. In this case, using an `Agent` is more convenient:
+
+```javascript
+var agent = new (require('http2').Agent)({
+  key: fs.readFileSync('./example/localhost.key'),
+  ca: fs.readFileSync('./example/localhost.crt')
+});
+agent.get('https://localhost:8080/', function(response) {
   response.pipe(process.stdout);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -46,19 +46,6 @@ require('http2').get('https://localhost:8080/', function(response) {
 });
 ```
 
-Self-signed certificates must be specified for each request to avoid
-verification errors. In this case, using an `Agent` is more convenient:
-
-```javascript
-var agent = new (require('http2').Agent)({
-  key: fs.readFileSync('./example/localhost.key'),
-  ca: fs.readFileSync('./example/localhost.crt')
-});
-agent.get('https://localhost:8080/', function(response) {
-  response.pipe(process.stdout);
-});
-```
-
 ### Simple static file server ###
 
 An simple static file server serving up content from its own directory is available in the `example`

--- a/example/client.js
+++ b/example/client.js
@@ -4,11 +4,13 @@ var http2 = require('..');
 
 // Setting the global logger (optional)
 http2.globalAgent = new http2.Agent({
+  // Avoid verification errors for self-signed certs.
+  key: fs.readFileSync(path.join(__dirname, '/localhost.key')),
+  ca: fs.readFileSync(path.join(__dirname, '/localhost.crt')),
+  strictSSL: true,
+  rejectUnauthorized: true,
   log: require('../test/util').createLogger('client')
 });
-
-// We use self signed certs in the example code so we ignore cert errors
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 // Sending the request
 var url = process.argv.pop();

--- a/lib/http.js
+++ b/lib/http.js
@@ -871,11 +871,16 @@ Agent.prototype.request = function request(options, callback) {
   // * HTTP/2 over TLS negotiated using NPN or ALPN, or fallback to HTTPS1
   else {
     var started = false;
+    var createAgent = hasAgentOptions(options);
     options.ALPNProtocols = supportedProtocols;
     options.NPNProtocols = supportedProtocols;
     options.servername = options.host; // Server Name Indication
-    options.agent = this._httpsAgent;
     options.ciphers = options.ciphers || cipherSuites;
+    if (createAgent) {
+      options.agent = new https.Agent(options);
+    } else if (options.agent == null) {
+      options.agent = this._httpsAgent;
+    }
     var httpsRequest = https.request(options);
 
     httpsRequest.on('socket', function(socket) {
@@ -945,6 +950,17 @@ function unbundleSocket(socket) {
   socket.unpipe();
   delete socket.ondata;
   delete socket.onend;
+}
+
+function hasAgentOptions(options) {
+  return options.pfx != null ||
+    options.key != null ||
+    options.passphrase != null ||
+    options.cert != null ||
+    options.ca != null ||
+    options.ciphers != null ||
+    options.rejectUnauthorized != null ||
+    options.secureProtocol != null;
 }
 
 Object.defineProperty(Agent.prototype, 'maxSockets', {

--- a/lib/http.js
+++ b/lib/http.js
@@ -811,10 +811,9 @@ function Agent(options) {
   //   generating the key identifying the connection, so we may get useless non-negotiated TLS
   //   channels even if we ask for a negotiated one. This agent will contain only negotiated
   //   channels.
-  var agentOptions = {};
-  agentOptions.ALPNProtocols = supportedProtocols;
-  agentOptions.NPNProtocols = supportedProtocols;
-  this._httpsAgent = new https.Agent(agentOptions);
+  options.ALPNProtocols = supportedProtocols;
+  options.NPNProtocols = supportedProtocols;
+  this._httpsAgent = new https.Agent(options);
 
   this.sockets = this._httpsAgent.sockets;
   this.requests = this._httpsAgent.requests;


### PR DESCRIPTION
Hi there! This is a small change that allows clients to specify self-signed certificates without disabling verification entirely.