### PR TITLE
Set max listeners on Agent to unlimited.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -800,6 +800,7 @@ function getTLS(options, callback) {
 
 function Agent(options) {
   EventEmitter.call(this);
+  this.setMaxListeners(0);
 
   options = util._extend({}, options);
 


### PR DESCRIPTION
This fixes a warning on node v0.10.25:
"warning: possible EventEmitter memory leak detected. 11 listeners added. Use
emitter.setMaxListeners() to increase limit."

The warning is triggered by firing off more than ten requests at once.