### PR TITLE
Add remoteAddress and remotePort to the request handler's request.socket

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -460,6 +460,11 @@ Server.prototype._start = function _start(socket) {
     var response = new OutgoingResponse(stream);
     var request = new IncomingRequest(stream);
 
+    // Some conformance to Node.js Https specs allows to distinguish clients:
+    request.remoteAddress = socket.remoteAddress;
+    request.remotePort = socket.remotePort;
+    request.socket = socket;
+
     request.once('ready', self.emit.bind(self, 'request', request, response));
   });
 


### PR DESCRIPTION
Node does that. It is convenient.