### PR TITLE
Save request in response

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -975,6 +975,7 @@ OutgoingRequest.prototype = Object.create(OutgoingMessage.prototype, { construct
 
 OutgoingRequest.prototype._start = function _start(stream, options) {
   this.stream = stream;
+  this.options = options;
 
   this._log = stream._log.child({ component: 'http' });
 
@@ -1000,8 +1001,8 @@ OutgoingRequest.prototype._start = function _start(stream, options) {
   this.headersSent = true;
 
   this.emit('socket', this.stream);
-
   var response = new IncomingResponse(this.stream);
+  response.req = this;
   response.once('ready', this.emit.bind(this, 'response', response));
 
   this.stream.on('promise', this._onPromise.bind(this));

--- a/lib/http.js
+++ b/lib/http.js
@@ -865,6 +865,8 @@ Agent.prototype.request = function request(options, callback) {
       port: options.port,
       localAddress: options.localAddress
     });
+    
+    this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);
   }

--- a/lib/protocol/compressor.js
+++ b/lib/protocol/compressor.js
@@ -242,7 +242,7 @@ HeaderSetDecompressor.prototype._execute = function _execute(rep) {
   var entry, pair;
 
   if (rep.contextUpdate) {
-    this.setTableSizeLimit(rep.newMaxSize);
+   this._table.setSizeLimit(rep.newMaxSize);
   }
 
   // * An _indexed representation_ entails the following actions:


### PR DESCRIPTION
Saving request information in response.  Useful for handling multiple requests and responses in the same event handlers.