### PR TITLE
Clear Text setTableSizeLimit and saving endpoints fixes

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -865,6 +865,8 @@ Agent.prototype.request = function request(options, callback) {
       port: options.port,
       localAddress: options.localAddress
     });
+    
+    this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);
   }

--- a/lib/protocol/compressor.js
+++ b/lib/protocol/compressor.js
@@ -242,7 +242,7 @@ HeaderSetDecompressor.prototype._execute = function _execute(rep) {
   var entry, pair;
 
   if (rep.contextUpdate) {
-    this.setTableSizeLimit(rep.newMaxSize);
+   this._table.setSizeLimit(rep.newMaxSize);
   }
 
   // * An _indexed representation_ entails the following actions:


### PR DESCRIPTION
When receiving a table resize in HeaderSetDecompressor, this.setTableSizeLimit was undefined.
Now calling this._table.steSizeLimit directly.
The second fix is about adding new endpoints to agent.endpoint for clear text transactions.

Mistakenly had fixes on my fork's master.  I am making more changes, and don't want everything showing in one pull request.