### PR TITLE
Fix: In clear text, adding endpoint to Agent.endpoints

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -865,6 +865,8 @@ Agent.prototype.request = function request(options, callback) {
       port: options.port,
       localAddress: options.localAddress
     });
+    
+    this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);
   }


### PR DESCRIPTION
New Endpoints were not being added to the agent.  Every request to the origin was creating a new request. This was happening in http only