### PR TITLE
Fix to HeaderSetDecompressor table resize.

### DIFF
--- a/lib/protocol/compressor.js
+++ b/lib/protocol/compressor.js
@@ -242,7 +242,7 @@ HeaderSetDecompressor.prototype._execute = function _execute(rep) {
   var entry, pair;
 
   if (rep.contextUpdate) {
-   this._table.setSizeLimit(rep.newMaxSize);
+    this._table.setSizeLimit(rep.newMaxSize);
   }
 
   // * An _indexed representation_ entails the following actions:

--- a/lib/protocol/compressor.js
+++ b/lib/protocol/compressor.js
@@ -242,7 +242,7 @@ HeaderSetDecompressor.prototype._execute = function _execute(rep) {
   var entry, pair;
 
   if (rep.contextUpdate) {
-    this.setTableSizeLimit(rep.newMaxSize);
+   this._table.setSizeLimit(rep.newMaxSize);
   }
 
   // * An _indexed representation_ entails the following actions:


### PR DESCRIPTION
When recieving a table resize in HeaderSetDecompressor, this.setTableSizeLimit was undefined.
Now calling this._table.steSizeLimit directly.