### PR TITLE
Update node versions tested on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
  language: node_js
  node_js:
-   - "0.11"
-   - "0.10"
+   - "iojs"
+   - "0.12"
 


### PR DESCRIPTION
* Enable testing on iojs and node 0.12 (since we support both)
* Stop testing on node < 0.12 (since that's no longer supported)