### PR TITLE
Re-emit socket errors for client requests.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -849,6 +849,7 @@ Agent.prototype.request = function request(options, callback) {
     options.host,
     options.port
   ].join(':');
+  var self = this;
 
   // * There's an existing HTTP/2 connection to this host
   if (key in this.endpoints) {
@@ -864,7 +865,12 @@ Agent.prototype.request = function request(options, callback) {
       port: options.port,
       localAddress: options.localAddress
     });
-    
+
+    endpoint.socket.on('error', function (error) {
+      self._log.error('Socket error: ' + error.toString());
+      request.emit('error', error);
+    });
+
     this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);
@@ -884,6 +890,11 @@ Agent.prototype.request = function request(options, callback) {
       options.agent = this._httpsAgent;
     }
     var httpsRequest = https.request(options);
+    
+    httpsRequest.on('error', function (error) {
+      self._log.error('Socket error: ' + error.toString());
+      request.emit('error', error);
+    });
 
     httpsRequest.on('socket', function(socket) {
       var negotiatedProtocol = socket.alpnProtocol || socket.npnProtocol;
@@ -894,7 +905,6 @@ Agent.prototype.request = function request(options, callback) {
       }
     });
 
-    var self = this;
     function negotiated() {
       var endpoint;
       var negotiatedProtocol = httpsRequest.socket.alpnProtocol || httpsRequest.socket.npnProtocol;

--- a/test/http.js
+++ b/test/http.js
@@ -543,6 +543,52 @@ describe('http.js', function() {
         });
       });
     });
+    describe('Handle socket error', function () {
+      it('HTTPS on Connection Refused error', function (done) {
+        var path = '/x';
+        var request = http2.request('https://127.0.0.1:6666' + path);
+
+        request.on('error', function (err) {
+          expect(err.errno).to.equal('ECONNREFUSED');
+          done();
+        });
+
+        request.on('response', function (response) {
+          server._server._handle.destroy();
+
+          response.on('data', util.noop);
+
+          response.once('end', function () {
+            done(new Error('Request should have failed'));
+          });
+        });
+
+        request.end();
+
+      });
+      it('HTTP on Connection Refused error', function (done) {
+        var path = '/x';
+
+        var request = http2.raw.request('http://127.0.0.1:6666' + path);
+
+        request.on('error', function (err) {
+          expect(err.errno).to.equal('ECONNREFUSED');
+          done();
+        });
+
+        request.on('response', function (response) {
+          server._server._handle.destroy();
+
+          response.on('data', util.noop);
+
+          response.once('end', function () {
+            done(new Error('Request should have failed'));
+          });
+        });
+
+        request.end();
+      });
+    });
     describe('server push', function() {
       it('should work as expected', function(done) {
         var path = '/x';


### PR DESCRIPTION
Old behaviour was to throw unhanded exceptions. This fix should handle
exceptions from both plain text and encrypted requests. Includes tests
for plain and encrypted.  

I think this should also fix bug #117; however, I could not re produce the error the test case given.  @jsha can you check with this branch?