### PR TITLE
Send PROTOCOL_ERROR if the first frame is not SETTINGS

### DIFF
--- a/lib/protocol/connection.js
+++ b/lib/protocol/connection.js
@@ -401,7 +401,7 @@ Connection.prototype._onFirstFrameReceived = function _onFirstFrameReceived(fram
     this._log.debug('Receiving the first SETTINGS frame as part of the connection header.');
   } else {
     this._log.fatal({ frame: frame }, 'Invalid connection header: first frame is not SETTINGS.');
-    this.emit('error');
+    this.emit('error', 'PROTOCOL_ERROR');
   }
 };
 


### PR DESCRIPTION
I think [RFC7540](https://tools.ietf.org/html/rfc7540#section-3.5) says that a server should return PROTOCOL_ERROR if the first frame is not SETTINGS.