### PR TITLE
Forward `listening` and `error` events.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -396,6 +396,36 @@ exports.IncomingRequest = IncomingRequest;
 exports.OutgoingResponse = OutgoingResponse;
 exports.ServerResponse = OutgoingResponse; // for API compatibility
 
+// Forward events `event` on `source` to all listeners on `target`.
+//
+// Note: The calling context is `source`.
+function forwardEvent(event, source, target) {
+  function forward() {
+    var listeners = target.listeners(event);
+
+    var n = listeners.length;
+
+    // Special case for `error` event with no listeners.
+    if (n === 0 && event === 'error') {
+      var args = [event];
+      args.push.apply(args, arguments);
+
+      target.emit.apply(target, args);
+      return;
+    }
+
+    for (var i = 0; i < n; ++i) {
+      listeners[i].apply(source, arguments);
+    }
+  }
+
+  source.on(event, forward);
+
+  // A reference to the function is necessary to be able to stop
+  // forwarding.
+  return forward;
+}
+
 // Server class
 // ------------
 
@@ -430,6 +460,9 @@ function Server(options) {
       }
     });
     this._server.on('request', this.emit.bind(this, 'request'));
+
+    forwardEvent('error', this._server, this);
+    forwardEvent('listening', this._server, this);
   }
 
   // HTTP2 over plain TCP

--- a/test/http.js
+++ b/test/http.js
@@ -38,6 +38,36 @@ describe('http.js', function() {
         }).to.throw(Error);
       });
     });
+    describe('method `listen()`', function () {
+      it('should emit `listening` event', function (done) {
+        var server = http2.createServer(serverOptions);
+
+        server.on('listening', function () {
+          server.close();
+
+          done();
+        })
+
+        server.listen(0);
+      });
+      it('should emit `error` on failure', function (done) {
+        var server = http2.createServer(serverOptions);
+
+        // This TCP server is used to explicitly take a port to make
+        // server.listen() fails.
+        var net = require('net').createServer();
+
+        server.on('error', function () {
+          net.close()
+
+          done();
+        });
+
+        net.listen(0, function () {
+          server.listen(this.address().port);
+        });
+      });
+    });
     describe('property `timeout`', function() {
       it('should be a proxy for the backing HTTPS server\'s `timeout` property', function() {
         var server = new http2.Server(serverOptions);


### PR DESCRIPTION
`listening` event is currently not forwarded which force the user to pass a callback to `.listen()`.
This breaks certain patterns such as the use of [event-to-promise](https://www.npmjs.com/package/event-to-promise).

The problem is worst for the `error` event: because it is not forwarded, it will crash the process.