### PR TITLE
event forwarding fixes

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -539,6 +539,7 @@ Server.prototype.on = function on(event, listener) {
   } else {
     EventEmitter.prototype.on.call(this, event, listener);
   }
+  return this;
 };
 
 // `addContext` is used to add Server Name Indication contexts
@@ -750,6 +751,7 @@ OutgoingResponse.prototype.on = function on(event, listener) {
   } else {
     OutgoingMessage.prototype.on.call(this, event, listener);
   }
+  return this;
 };
 
 // Client side
@@ -1055,6 +1057,7 @@ OutgoingRequest.prototype.on = function on(event, listener) {
   } else {
     OutgoingMessage.prototype.on.call(this, event, listener);
   }
+  return this;
 };
 
 // Methods only in fallback mode

--- a/lib/http.js
+++ b/lib/http.js
@@ -407,7 +407,7 @@ function Server(options) {
 
   var start = this._start.bind(this);
   var fallback = this._fallback.bind(this);
-
+  this._listenerCache = new WeakMap();
   // HTTP2 over TLS (using NPN or ALPN)
   if ((options.key && options.cert) || options.pfx) {
     this._log.info('Creating HTTP/2 server over TLS');
@@ -534,14 +534,26 @@ Object.defineProperty(Server.prototype, 'timeout', {
 // listening on the event or not. In these cases, we can not simply forward the events from the
 // `server` to `this` since that means a listener. Instead, we forward the subscriptions.
 Server.prototype.on = function on(event, listener) {
-  if ((event === 'upgrade') || (event === 'timeout')) {
-    this._server.on(event, listener && listener.bind(this));
+  if ((event === 'upgrade') || (event === 'timeout') || (event === 'error')) {
+    var boundListener = listener.bind(this);
+    this._listenerCache.set(listener, boundListener);
+    this._server.on(event, boundListener);
   } else {
     EventEmitter.prototype.on.call(this, event, listener);
   }
   return this;
 };
-
+Server.prototype.removeListener = function on(event, listener) {
+  if ((event === 'upgrade') || (event === 'timeout') || (event === 'error')) {
+    var boundListener = this._listenerCache.get(listener);
+    if (boundListener) {
+      this._server.removeListener(event, listener);
+    }
+  } else {
+    EventEmitter.prototype.removeListener.call(this, event, listener);
+  }
+  return this;
+};
 // `addContext` is used to add Server Name Indication contexts
 Server.prototype.addContext = function addContext(hostname, credentials) {
   if (this._mode === 'tls') {
@@ -658,7 +670,7 @@ function OutgoingResponse(stream) {
   this.stream = stream;
   this.statusCode = 200;
   this.sendDate = true;
-
+  this._listenerCache = new WeakMap();
   this.stream.once('headers', this._onRequestHeaders.bind(this));
 }
 OutgoingResponse.prototype = Object.create(OutgoingMessage.prototype, { constructor: { value: OutgoingResponse } });
@@ -746,14 +758,26 @@ OutgoingResponse.prototype.altsvc = function altsvc(host, port, protocolID, maxA
 // Overriding `EventEmitter`'s `on(event, listener)` method to forward certain subscriptions to
 // `request`. See `Server.prototype.on` for explanation.
 OutgoingResponse.prototype.on = function on(event, listener) {
-  if (this.request && (event === 'timeout')) {
-    this.request.on(event, listener && listener.bind(this));
+  if (this.request && ((event === 'timeout') || (event === 'error'))) {
+    var boundListener = listener.bind(this);
+    this._listenerCache.set(listener, boundListener);
+    this.request.on(event, boundListener);
   } else {
     OutgoingMessage.prototype.on.call(this, event, listener);
   }
   return this;
 };
-
+OutgoingResponse.prototype.removeListener = function removeListener(event, listener) {
+  if (this.request && ((event === 'timeout') || (event === 'error'))) {
+    var boundListener = this._listenerCache.get(listener);
+    if (boundListener) {
+      this.request.removeListener(event, boundListener);
+    }
+  } else {
+    OutgoingMessage.prototype.removeListener.call(this, event, listener);
+  }
+  return this;
+};
 // Client side
 // ===========
 
@@ -876,7 +900,7 @@ Agent.prototype.request = function request(options, callback) {
       port: options.port,
       localAddress: options.localAddress
     });
-    
+
     this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);
@@ -995,7 +1019,7 @@ function OutgoingRequest() {
   OutgoingMessage.call(this);
 
   this._log = undefined;
-
+  this._listenerCache = new WeakMap();
   this.stream = undefined;
 }
 OutgoingRequest.prototype = Object.create(OutgoingMessage.prototype, { constructor: { value: OutgoingRequest } });
@@ -1052,14 +1076,26 @@ OutgoingRequest.prototype.setPriority = function setPriority(priority) {
 // Overriding `EventEmitter`'s `on(event, listener)` method to forward certain subscriptions to
 // `request`. See `Server.prototype.on` for explanation.
 OutgoingRequest.prototype.on = function on(event, listener) {
-  if (this.request && (event === 'upgrade')) {
-    this.request.on(event, listener && listener.bind(this));
+  if (this.request && ((event === 'upgrade') || (event === 'error'))) {
+    var boundListener = listener.bind(this);
+    this._listenerCache.set(listener, boundListener);
+    this.request.on(event, listener);
   } else {
     OutgoingMessage.prototype.on.call(this, event, listener);
   }
   return this;
 };
-
+OutgoingRequest.prototype.removeListener = function on(event, listener) {
+  if (this.request && ((event === 'upgrade') || (event === 'error'))) {
+    var boundListener = this._listenerCache.get(listener);
+    if (boundListener) {
+      this.request.removeListener(event, boundListener);
+    }
+  } else {
+    OutgoingMessage.prototype.removeListener.call(this, event, listener);
+  }
+  return this;
+};
 // Methods only in fallback mode
 OutgoingRequest.prototype.setNoDelay = function setNoDelay(noDelay) {
   if (this.request) {


### PR DESCRIPTION
the `on` method for events should return `this` so as to allow method chaining, broke some code where it didn't (this is documented behavior of the event object)