### PR TITLE
Fixes for issue raised in #161 - missing finished field

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -328,6 +328,7 @@ function OutgoingMessage() {
   this._headers = {};
   this._trailers = undefined;
   this.headersSent = false;
+  this.finished = false;
 
   this.on('finish', this._finish);
 }
@@ -350,6 +351,7 @@ OutgoingMessage.prototype._finish = function _finish() {
         this.stream.headers(this._trailers);
       }
     }
+    this.finished = true;
     this.stream.end();
   } else {
     this.once('socket', this._finish.bind(this));
@@ -658,6 +660,7 @@ function OutgoingResponse(stream) {
   this.statusCode = 200;
   this.sendDate = true;
 
+
   this.stream.once('headers', this._onRequestHeaders.bind(this));
 }
 OutgoingResponse.prototype = Object.create(OutgoingMessage.prototype, { constructor: { value: OutgoingResponse } });
@@ -702,6 +705,7 @@ OutgoingResponse.prototype.write = function write() {
 };
 
 OutgoingResponse.prototype.end = function end() {
+  this.finshed = true;
   this._implicitHeaders();
   return OutgoingMessage.prototype.end.apply(this, arguments);
 };
@@ -874,7 +878,7 @@ Agent.prototype.request = function request(options, callback) {
       port: options.port,
       localAddress: options.localAddress
     });
-    
+
     this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);

--- a/package.json
+++ b/package.json
@@ -3,15 +3,16 @@
   "version": "3.2.0",
   "description": "An HTTP/2 client and server implementation",
   "main": "lib/index.js",
-  "engines" : {
-    "node" : ">=0.12.0"
+  "engines": {
+    "node": ">=0.12.0"
   },
   "devDependencies": {
-    "istanbul": "*",
+    "bunyan": "*",
     "chai": "*",
-    "mocha": "*",
     "docco": "*",
-    "bunyan": "*"
+    "istanbul": "*",
+    "mocha": "*",
+    "server-destroy": "^1.0.1"
   },
   "scripts": {
     "test": "istanbul test _mocha -- --reporter spec --slow 500 --timeout 15000",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,15 @@
   "version": "3.2.0",
   "description": "An HTTP/2 client and server implementation",
   "main": "lib/index.js",
-  "engines": {
-    "node": ">=0.12.0"
+  "engines" : {
+    "node" : ">=0.12.0"
   },
   "devDependencies": {
-    "bunyan": "*",
-    "chai": "*",
-    "docco": "*",
     "istanbul": "*",
+    "chai": "*",
     "mocha": "*",
-    "server-destroy": "^1.0.1"
+    "docco": "*",
+    "bunyan": "*"
   },
   "scripts": {
     "test": "istanbul test _mocha -- --reporter spec --slow 500 --timeout 15000",

--- a/test/http.js
+++ b/test/http.js
@@ -161,6 +161,31 @@ describe('http.js', function() {
       response.writeHead(200);
       response.writeHead(404);
     });
+    it('field finished should be Boolean', function(){
+      var stream = { _log: util.log, headers: function () {}, once: util.noop };
+      var response = new http2.OutgoingResponse(stream);
+      expect(response.finished).to.be.a('Boolean');
+    });
+    it('field finished should initially be false and then go to true when response completes',function(done){
+      var res;
+      var server = http2.createServer(serverOptions, function(request, response) {
+        res = response;
+        expect(res.finished).to.be.false;
+        response.end('HiThere');
+      });
+      server.listen(1236, function() {
+        http2.get('https://localhost:1236/finished-test', function(response) {
+          response.on('data', function(data){
+            var sink = data; //
+          });
+          response.on('end',function(){
+            expect(res.finished).to.be.true;
+            server.close();
+            done();
+          });
+        });
+      });
+    });
   });
   describe('test scenario', function() {
     describe('simple request', function() {


### PR DESCRIPTION
This is changes and new tests to add a finished field into OutgoingMessage to make it compatible with the other node modules - specifically `on-finished` which is used by `send` which is used by `serve-static`.