### PR TITLE
Allow chaining for Server.listen and Server.on

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -536,6 +536,8 @@ Server.prototype.listen = function listen(port, hostname) {
   this._log.info({ on: ((typeof hostname === 'string') ? (hostname + ':' + port) : port) },
                  'Listening for incoming connections');
   this._server.listen.apply(this._server, arguments);
+
+  return this._server;
 };
 
 Server.prototype.close = function close(callback) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -572,9 +572,9 @@ Object.defineProperty(Server.prototype, 'timeout', {
 // `server` to `this` since that means a listener. Instead, we forward the subscriptions.
 Server.prototype.on = function on(event, listener) {
   if ((event === 'upgrade') || (event === 'timeout')) {
-    this._server.on(event, listener && listener.bind(this));
+    return this._server.on(event, listener && listener.bind(this));
   } else {
-    EventEmitter.prototype.on.call(this, event, listener);
+    return EventEmitter.prototype.on.call(this, event, listener);
   }
 };
 


### PR DESCRIPTION
node-http2 behaves differently compared to the standard node http- and https-API when it comes to the return value of `Server.listen()` and `Server.on()`.

This PR adapts the behavior of the original node APIs.