### PR TITLE
Update the check on deprecated headers

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -155,7 +155,6 @@ var deprecatedHeaders = [
   'host',
   'keep-alive',
   'proxy-connection',
-  'te',
   'transfer-encoding',
   'upgrade'
 ];
@@ -290,12 +289,13 @@ IncomingMessage.prototype._checkSpecialHeader = function _checkSpecialHeader(key
 
 IncomingMessage.prototype._validateHeaders = function _validateHeaders(headers) {
   // * An HTTP/2.0 request or response MUST NOT include any of the following header fields:
-  //   Connection, Host, Keep-Alive, Proxy-Connection, TE, Transfer-Encoding, and Upgrade. A server
+  //   Connection, Host, Keep-Alive, Proxy-Connection, Transfer-Encoding, and Upgrade. A server
   //   MUST treat the presence of any of these header fields as a stream error of type
   //   PROTOCOL_ERROR.
+  //  If the TE header is present, it's only valid value is 'trailers'
   for (var i = 0; i < deprecatedHeaders.length; i++) {
     var key = deprecatedHeaders[i];
-    if (key in headers) {
+    if (key in headers || (key === 'te' && headers[key] !== 'trailers')) {
       this._log.error({ key: key, value: headers[key] }, 'Deprecated header found');
       this.stream.reset('PROTOCOL_ERROR');
       return;


### PR DESCRIPTION
Allow 'te' to have value 'trailers'.

From the HTTP2.0 spec:
[https://httpwg.github.io/specs/rfc7540.html#rfc.section.8.1.2]

HTTP/2 does not use the Connection header field to indicate
connection-specific header fields; in this protocol, connection-specific
metadata is conveyed by other means. An endpoint MUST NOT generate an
HTTP/2 message containing connection-specific header fields; any message
containing connection-specific header fields MUST be treated as
malformed (Section 8.1.2.6).

> The only exception to this is the TE header field, which MAY be
> present in an HTTP/2 request; when it is, it MUST NOT contain any
> value other than "trailers".