### PR TITLE
Avoid firing window_update unnecessarily.

### DIFF
--- a/lib/protocol/flow.js
+++ b/lib/protocol/flow.js
@@ -323,7 +323,9 @@ Flow.prototype._increaseWindow = function _increaseWindow(size) {
       this._log.error('Flow control window grew too large.');
       this.emit('error', 'FLOW_CONTROL_ERROR');
     } else {
-      this.emit('window_update');
+      if (size != 0) {
+        this.emit('window_update');
+      }
     }
   }
 };


### PR DESCRIPTION
Currently, the following scenario can occur

- a new connection is created; a new stream is created and a large
  payload is sent on it

- the large payload exhausts its window and gets blocked

- flow._read() calls .once('window_update', this._read) to be unblocked
  when a window update is received

- at this point, the window_update event from the receipt of settings
  for the connection is received.  This usually won't update the window,
  unless the remote window was much larger the original local window.
  However, it triggers the window_update event handler that was
  registered for unblocking the read

- subsequently, the when WINDOW_UPDATE that actually update the window
  for stream is received, the read is no longer listening for it.

This change resolves the problem by only firing the 'window_update'
event if the window changes.  This is a simple way of prevent the
`SETTINGS receipt` window_update events taking up window_update events
registered by reads