### PR TITLE
Allow receipt of WINDOW_UPDATE on closed streams

### DIFF
--- a/lib/protocol/stream.js
+++ b/lib/protocol/stream.js
@@ -567,8 +567,9 @@ Stream.prototype._transition = function transition(sending, frame) {
     //   can be used to close any of those streams.
     case 'CLOSED':
       if (PRIORITY || (sending && RST_STREAM) ||
+          (receiving && WINDOW_UPDATE) ||
           (receiving && this._closedByUs &&
-           (this._closedWithRst || WINDOW_UPDATE || RST_STREAM || ALTSVC))) {
+           (this._closedWithRst || RST_STREAM || ALTSVC))) {
         /* No state change */
       } else {
         streamError = 'STREAM_CLOSED';

--- a/test/stream.js
+++ b/test/stream.js
@@ -192,7 +192,7 @@ describe('stream.js', function() {
         stream.headers({});
         stream.end();
         stream.upstream.write({ type: 'HEADERS', headers:{}, flags: { END_STREAM: true }, count_change: util.noop });
-        example_frames.slice(1).forEach(function(invalid_frame) {
+        example_frames.slice(2).forEach(function(invalid_frame) {
           invalid_frame.count_change = util.noop;
           expect(stream._transition.bind(stream, false, invalid_frame)).to.throw('Uncaught, unspecified "error" event.');
         });


### PR DESCRIPTION
https://httpwg.github.io/specs/rfc7540.html#StreamStates

'WINDOW_UPDATE or RST_STREAM frames can be received in this state for a
short period after a DATA or HEADERS frame containing an END_STREAM flag
is sent.'

The current logic does not allow this work in all valid cases,