### PR TITLE
Adds address function for compatibility with core http and https modules

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -583,6 +583,10 @@ Server.prototype.addContext = function addContext(hostname, credentials) {
   }
 };
 
+Server.prototype.address = function address() {
+  return this._server.address()
+};
+
 function createServerRaw(options, requestListener) {
   if (typeof options === 'function') {
     requestListener = options;


### PR DESCRIPTION
I'm experiencing issues when using http2 with other modules that expect the same interface as the core http server. The `.address()` method seems to be the main culprit. 

Resolves #157