### PR TITLE
Add ability to specify endpoint key

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -861,6 +861,7 @@ function Agent(options) {
 
   this._settings = options.settings;
   this._log = (options.log || defaultLogger).child({ component: 'http' });
+  this._endpointKey = options.endpointKey;
   this.endpoints = {};
 
   // * Using an own HTTPS agent, because the global agent does not look at `NPN/ALPNProtocols` when
@@ -900,7 +901,7 @@ Agent.prototype.request = function request(options, callback) {
     request.on('response', callback);
   }
 
-  var key = [
+  var key = this._endpointKey || [
     !!options.plain,
     options.host,
     options.port


### PR DESCRIPTION
Spec says there can be only one connection per host/port, but there is a case with Apple Push Notifications Service where one host/port can be used with multiple certificates. This pull request makes it possible. 

Not sure whether this should be merged, but I think it won't hurt.