### PR TITLE
Ability to handle FRAME_SIZE_ERROR gracefully as a connection error. …

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -927,6 +927,11 @@ Agent.prototype.request = function request(options, callback) {
       request.emit('error', error);
     });
 
+    endpoint.on('error', function(error){
+      self._log.error('Connection error: ' + error.toString());
+      request.emit('error', error);
+    });
+
     this.endpoints[key] = endpoint;
     endpoint.pipe(endpoint.socket).pipe(endpoint);
     request._start(endpoint.createStream(), options);


### PR DESCRIPTION
this happens frequently with NO_TLS connection, and relates to a dependent 
[project issue](https://github.com/sdavis-r7/http2-probe/issues/8) when trying to establish 80/TCP NO_TLS connections.



