### PR TITLE
Ensure Set-Cookie headers are always an array

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -261,7 +261,11 @@ IncomingMessage.prototype._onHeaders = function _onHeaders(headers) {
   // * Store the _regular_ headers in `this.headers`
   for (var name in headers) {
     if (name[0] !== ':') {
-      this.headers[name] = headers[name];
+      if (name === 'set-cookie' && !Array.isArray(headers[name])) {
+        this.headers[name] = [headers[name]];
+      } else {
+        this.headers[name] = headers[name];
+      }
     }
   }
 

--- a/test/http.js
+++ b/test/http.js
@@ -349,6 +349,9 @@ describe('http.js', function() {
           response.removeHeader('nonexistent');
           expect(response.getHeader('nonexistent')).to.equal(undefined);
 
+          // A set-cookie header which should always be an array
+          response.setHeader('set-cookie', 'foo');
+
           // Don't send date
           response.sendDate = false;
 
@@ -375,6 +378,8 @@ describe('http.js', function() {
           request.on('response', function(response) {
             expect(response.headers[headerName]).to.equal(headerValue);
             expect(response.headers['nonexistent']).to.equal(undefined);
+            expect(response.headers['set-cookie']).to.an.instanceof(Array)
+            expect(response.headers['set-cookie']).to.deep.equal(['foo'])
             expect(response.headers['date']).to.equal(undefined);
             response.on('data', function(data) {
               expect(data.toString()).to.equal(message);


### PR DESCRIPTION
If I understand the purpose of this project correctly, one of the goals is to be 100% API compatible with the Node.js core http/https modules. 

I found a minor difference in the way that http2 handles the `Set-Cookie` header: Node core will force it to be an array even if it the HTTP response only contains a single `Set-Coolie` header ([source code](https://github.com/nodejs/node/blob/fab240a886b69ef9fa78573fc210c15cfe0018f0/lib/_http_incoming.js#L127-L133)).

This pull request tries to add the same functionality to the http2 module. It works with this PR, but I'm not entirely sure I've added the logic in the correct location as I had a hard time figuring out the structure of the source code. Please let me know if you want me to modify my pull request.