### PR TITLE
set agent max listeners to infinite

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -856,6 +856,7 @@ function getTLS(options, callback) {
 
 function Agent(options) {
   EventEmitter.call(this);
+  this.setMaxListeners(0);
 
   options = util._extend({}, options);
 


### PR DESCRIPTION
This is a reopen of PR #115 which had been closed too fast.

It fix a warning triggered by firing off more than ten requests at once.

```
warning: possible EventEmitter memory leak detected. 11 listeners added. Use
emitter.setMaxListeners() to increase limit.
```

It happens on all NodeJS versions (including latest 5.x)
