### PR TITLE
removing unnecessary files and directories from npm pkg

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+.travis.yml


### PR DESCRIPTION
I would recommend adding a these files/dirs to the .npmignore file since they are unnecessary for the user downloading the package and they can still get these files and directories by cloning the repo.