### PR TITLE
Assign socket to response

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -503,7 +503,7 @@ Server.prototype._start = function _start(socket) {
     // Some conformance to Node.js Https specs allows to distinguish clients:
     request.remoteAddress = socket.remoteAddress;
     request.remotePort = socket.remotePort;
-    request.connection = request.socket = socket;
+    request.connection = request.socket = response.socket = socket;
 
     request.once('ready', self.emit.bind(self, 'request', request, response));
   });


### PR DESCRIPTION
Because `http`,` https` module have `response.socket` (which is the same `request.socket`).

if this module haven't `response.socket`, it will make some of the modules not work. (Like [koa/lib/response.js](https://github.com/koajs/koa/blob/master/lib/response.js#L489))