### PR TITLE
Leak less listeners on error

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -949,6 +949,7 @@ Agent.prototype.request = function request(options, callback) {
 
     httpsRequest.on('error', function (error) {
       self._log.error('Socket error: ' + error.toString());
+      self.removeAllListeners(key);
       request.emit('error', error);
     });
 


### PR DESCRIPTION
P.S. I'm not quite sure if this fix is complete and pervasive, but it prevents at least [one leak](https://github.com/molnarg/node-http2/blob/427e60c0255685df41090fbcf104e706b5ae08f2/lib/http.js#L993) for sure, which happens when error is emitted before the connection is established (for example, domain name can't be resolved).