### PR TITLE
Clean up ended streams to free memory

### DIFF
--- a/lib/protocol/connection.js
+++ b/lib/protocol/connection.js
@@ -214,6 +214,11 @@ Connection.prototype._insert = function _insert(stream, priority) {
 };
 
 Connection.prototype._reprioritize = function _reprioritize(stream, priority) {
+  this._removePrioritisedStream(stream);
+  this._insert(stream, priority);
+};
+
+Connection.prototype._removePrioritisedStream = function _removePrioritisedStream(stream) {
   var bucket = this._streamPriorities[stream._priority];
   var index = bucket.indexOf(stream);
   assert(index !== -1);
@@ -221,9 +226,7 @@ Connection.prototype._reprioritize = function _reprioritize(stream, priority) {
   if (bucket.length === 0) {
     delete this._streamPriorities[stream._priority];
   }
-
-  this._insert(stream, priority);
-};
+}
 
 // Creating an *inbound* stream with the given ID. It is called when there's an incoming frame to
 // a previously nonexistent stream.
@@ -234,6 +237,8 @@ Connection.prototype._createIncomingStream = function _createIncomingStream(id) 
   this._allocateId(stream, id);
   this._allocatePriority(stream);
   this.emit('stream', stream, id);
+
+  stream.on('end', this._removeStream.bind(this, stream));
 
   return stream;
 };
@@ -246,8 +251,17 @@ Connection.prototype.createStream = function createStream() {
   var stream = new Stream(this._log, this);
   this._allocatePriority(stream);
 
+  stream.on('end', this._removeStream.bind(this, stream));
+
   return stream;
 };
+
+Connection.prototype._removeStream = function _removeStream(stream) {
+  this._log.trace('Removing outbound stream.');
+
+  delete this._streamIds[stream.id];
+  this._removePrioritisedStream(stream);
+}
 
 // Multiplexing
 // ------------


### PR DESCRIPTION
Fixes #64 

When a stream ends remove references in `_streamIds` and `_streamPriorities`. This allows streams to be freed by the GC. (Verified with heap profiling)