### PR TITLE
set connection max listeners to infinite

### DIFF
--- a/lib/protocol/connection.js
+++ b/lib/protocol/connection.js
@@ -410,7 +410,10 @@ Connection.prototype._initializeSettingsManagement = function _initializeSetting
   this._log.debug({ settings: settings },
                   'Sending the first SETTINGS frame as part of the connection header.');
   this.set(settings || defaultSettings);
-
+  
+  // * Setting max listeners to infinite
+  this.setMaxListeners(0);
+  
   // * Forwarding SETTINGS frames to the `_receiveSettings` method
   this.on('SETTINGS', this._receiveSettings);
   this.on('RECEIVING_SETTINGS_MAX_FRAME_SIZE', this._sanityCheckMaxFrameSize);


### PR DESCRIPTION
Fix the warning when the request body is too large:

```
(node) warning: possible EventEmitter memory leak detected. 11 wakeup listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Connection.addListener (events.js:239:17)
    at Connection.Readable.on (_stream_readable.js:665:33)
    at Connection.once (events.js:265:8)
    at Connection._send (/root/js-psychokinesis/node_modules/http2/lib/protocol/connection.js:339:10)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```
