### PR TITLE
Grammar correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ API
 ---
 
 The API is very similar to the [standard node.js HTTPS API](http://nodejs.org/api/https.html). The
-goal is the perfect API compatibility, with additional HTTP2 related extensions (like server push).
+goal is perfect API compatibility, with additional HTTP2 related extensions (like server push).
 
 Detailed API documentation is primarily maintained in the `lib/http.js` file and is [available in
 the wiki](https://github.com/molnarg/node-http2/wiki/Public-API) as well.


### PR DESCRIPTION
The goal is the perfect API compatibility -> The goal is perfect API compatibility. It's more idiomatic English.