### PR TITLE
ignore inherited properties when iterating through flags

### DIFF
--- a/lib/protocol/framer.js
+++ b/lib/protocol/framer.js
@@ -218,10 +218,12 @@ Serializer.commonHeader = function writeCommonHeader(frame, buffers) {
 
   var flagByte = 0;
   for (var flag in frame.flags) {
-    var position = frameFlags[frame.type].indexOf(flag);
-    assert(position !== -1, 'Unknown flag for frame type ' + frame.type + ': ' + flag);
-    if (frame.flags[flag]) {
-      flagByte |= (1 << position);
+    if (frame.flags.hasOwnProperty(flag)) {
+      var position = frameFlags[frame.type].indexOf(flag);
+      assert(position !== -1, 'Unknown flag for frame type ' + frame.type + ': ' + flag);
+      if (frame.flags[flag]) {
+        flagByte |= (1 << position);
+      }
     }
   }
   headerBuffer.writeUInt8(flagByte, 4);


### PR DESCRIPTION
I extended the Object prototype and ran into this issue.